### PR TITLE
Add optional simd feature to optimize adler32 and miniz_oxide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,4 +64,4 @@ opt-level = 2
 
 [features]
 default = []
-simd = ['simd-adler32']
+simd = ['simd-adler32', 'miniz_oxide/simd']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ maintenance = { status = "actively-developed" }
 [dependencies.pix]
 version = "0.13"
 
+[dependencies.simd-adler32]
+version = "0.3"
+optional = true
+
 [dependencies.miniz_oxide]
 version = "0.7"
 
@@ -60,3 +64,4 @@ opt-level = 2
 
 [features]
 default = []
+simd = ['simd-adler32']

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -79,6 +79,7 @@ pub(crate) fn compress(outv: &mut Vec<u8>, inp: &[u8], level: u8) {
 }
 
 /// Return the Adler32 of the bytes data[0..len-1]
+#[cfg(not(feature = "simd"))]
 fn adler32(data: &[u8]) -> u32 {
     let adler = 1u32;
     let mut s1 = adler & u32::from(u16::MAX);
@@ -94,4 +95,12 @@ fn adler32(data: &[u8]) -> u32 {
         s2 %= 65521;
     }
     (s2 << 16) | s1
+}
+
+/// Return the Adler32 of the bytes data[0..len-1] (simd)
+#[cfg(feature = "simd")]
+fn adler32(data: &[u8]) -> u32 {
+    let mut adler = simd_adler32::Adler32::new();
+    adler.write(data);
+    adler.finish()
 }


### PR DESCRIPTION
In a benchmark that generates many small PNGs, half of the runtime is split between miniz deflate, and the other half in png_pong::zlib::adler32.  Replacing the built-in adler32 function with the optimized simd-adler32 crate makes the runtime of the adler32 function almost negligible.  This PR adds the 'simd' feature to select between the built-in function and the external crate.  It also enables simd optimizations for the miniz_oxide crate.