### PR TITLE
Integrate SIMD optimizations for adler32 and miniz_oxide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ version = "0.3"
 
 [dependencies.miniz_oxide]
 version = "0.7"
+features = ["simd"]
 
 [build-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ maintenance = { status = "actively-developed" }
 [dependencies.pix]
 version = "0.13"
 
+[dependencies.simd-adler32]
+version = "0.3"
+
 [dependencies.miniz_oxide]
 version = "0.7"
 

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -80,18 +80,7 @@ pub(crate) fn compress(outv: &mut Vec<u8>, inp: &[u8], level: u8) {
 
 /// Return the Adler32 of the bytes data[0..len-1]
 fn adler32(data: &[u8]) -> u32 {
-    let adler = 1u32;
-    let mut s1 = adler & u32::from(u16::MAX);
-    let mut s2 = (adler >> 16) & u32::from(u16::MAX);
-    // At least 5550 sums can be done before the sums overflow, saving a lot of
-    // modulo divisions
-    for part in data.chunks(5550) {
-        for &v in part {
-            s1 += v as u32;
-            s2 += s1;
-        }
-        s1 %= 65521;
-        s2 %= 65521;
-    }
-    (s2 << 16) | s1
+    let mut adler = simd_adler32::Adler32::new();
+    adler.write(data);
+    adler.finish()
 }


### PR DESCRIPTION
Based on #16 , but unconditionally includes simd-adler32

In a benchmark that generates many small PNGs, half of the runtime is split between miniz deflate, and the other half in `png_pong::zlib::adler32`. Replacing the built-in adler32 function with the optimized `simd-adler32` crate makes the runtime of the adler32 function almost negligible.  The simd feature from `miniz_oxide` is also enabled to make use of optimizations there.

